### PR TITLE
Edit PKCS7 verify calls and test data generation

### DIFF
--- a/library/pkcs7.c
+++ b/library/pkcs7.c
@@ -569,7 +569,7 @@ int mbedtls_pkcs7_signed_data_verify( mbedtls_pkcs7 *pkcs7,
 
     mbedtls_md( md_info, data, datalen, hash );
 
-    ret = mbedtls_pk_verify( &pk_cxt, md_alg, hash, sizeof(hash),
+    ret = mbedtls_pk_verify( &pk_cxt, md_alg, hash, 0,
                                       pkcs7->signed_data.signers.sig.p,
                                       pkcs7->signed_data.signers.sig.len );
 

--- a/tests/data_files/Makefile
+++ b/tests/data_files/Makefile
@@ -1139,9 +1139,9 @@ pkcs7-rsa-sha256-2.crt:
 	cat pkcs7-rsa-sha256-2.crt pkcs7-rsa-sha256-2.key > pkcs7-rsa-sha256-2.pem
 all_final += pkcs7-rsa-sha256-2.crt
 
-# Generate data file to be signed
+# Generate data file to be signed, (print binary of HELLO, prevents against new line differences in linux and windows)
 pkcs7_data.txt:
-	echo "Hello" > $@
+	echo -n -e '\x48\x65\x6c\x6c\x6f\x0a' > $@
 	echo 2 >> pkcs7_data_1.txt
 all_final += pkcs7_data.txt
 


### PR DESCRIPTION
This commit is to put an end to the tedious CI failures on Windows. The issue was that, when generating test files, Linux ends files with 0x0a while Windows ends with 0x0d0a. This was leading to a difference in generated hashes and pkcs7 signature verification failing. So this commit, hard codes the binary to echo'd into the test file. Additionally, I changed the calling of mbedtls_pk_verify because we were using the wrong value for hash length.

Signed-off-by: Nick Child <nick.child@ibm.com>
