### PR TITLE
Open PKCS7 data files in binary format

### DIFF
--- a/tests/suites/test_suite_pkcs7.function
+++ b/tests/suites/test_suite_pkcs7.function
@@ -216,7 +216,7 @@ void pkcs7_verify( char *pkcs7_file, char *crt, char *filetobesigned )
     res = stat(filetobesigned, &st);
     TEST_ASSERT( res == 0 );
 
-    file = fopen( filetobesigned, "r" );
+    file = fopen( filetobesigned, "rb" );
     TEST_ASSERT( file != NULL );
 
     datalen = st.st_size;


### PR DESCRIPTION
Previously, we were reading files in text mode. This was causing all of the 0x0d0a line breaks to be converted to unix line breaks. This will cause issues when comparing hashes of files. If we read the files in binary mode (fopen "rb") then we avoid this conversion.

Signed-off-by: Nick Child <nick.child@ibm.com>
