### PR TITLE
Add read in binary option to all tests

### DIFF
--- a/tests/suites/test_suite_pkcs7.function
+++ b/tests/suites/test_suite_pkcs7.function
@@ -275,7 +275,7 @@ void pkcs7_verify_hash( char *pkcs7_file, char *crt, char *filetobesigned )
     res = stat(filetobesigned, &st);
     TEST_ASSERT( res == 0 );
 
-    file = fopen( filetobesigned, "r" );
+    file = fopen( filetobesigned, "rb" );
     TEST_ASSERT( file != NULL );
 
     datalen = st.st_size;
@@ -334,7 +334,7 @@ void pkcs7_verify_badcert( char *pkcs7_file, char *crt, char *filetobesigned )
     res = stat(filetobesigned, &st);
     TEST_ASSERT( res == 0 );
 
-    file = fopen( filetobesigned, "r" );
+    file = fopen( filetobesigned, "rb" );
     TEST_ASSERT( file != NULL );
 
     datalen = st.st_size;
@@ -384,7 +384,7 @@ void pkcs7_verify_tampered_data( char *pkcs7_file, char *crt, char *filetobesign
     res = stat(filetobesigned, &st);
     TEST_ASSERT( res == 0 );
 
-    file = fopen( filetobesigned, "r" );
+    file = fopen( filetobesigned, "rb" );
     TEST_ASSERT( file != NULL );
 
     datalen = st.st_size;


### PR DESCRIPTION
In the previous commit we added option to read the test files in binary mode. This was to prevent the conversion from windows EOF to linux EOF. This is has proved to be successful in the CI so this commit adds the option to the rest of the tests

Signed-off-by: Nick Child <nick.child@ibm.com>
