### PR TITLE
pkcs7.c: Close file if alloc fails

### DIFF
--- a/library/pkcs7.c
+++ b/library/pkcs7.c
@@ -77,8 +77,12 @@ int mbedtls_pkcs7_load_file( const char *path, unsigned char **buf, size_t *n )
     fseek( file, 0, SEEK_SET );
 
     *buf = mbedtls_calloc( 1, *n + 1 );
-    if( *buf == NULL )
+    if( *buf == NULL ) 
+    {
+        fclose( file );
+        
         return( MBEDTLS_ERR_PKCS7_ALLOC_FAILED );
+    }
 
     if( fread( *buf, 1, *n, file ) != *n )
     {


### PR DESCRIPTION
The static analysis tool `cppcheck` will show that the function `mbedtls_pkcs7_load_file` does not properly close the opened file if memory allocation fails for the data `buf`. This commit ensures that, if a memory allocation error does occur, the  opened file will be closed before returning.

Signed-off-by: Nick Child <nick.child@ibm.com>
